### PR TITLE
Idea/FR: If the requestBody is empty allow the webhook to be ignored. If a config setting is enabled

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -119,7 +119,7 @@ class Plugin extends \craft\base\Plugin
 
                 // Check if it exists and if we we should send if it doesnt.
                 if (!$this->doesBodyHaveValue($body) && $this->getSettings()->dontSendEmptyRequestBody === true) {
-                    Craft::warning('Ignored webhook '. $webhook->name .' because the body was empty.', __METHOD__);
+                    Craft::warning('Ignored webhook '. $webhook->name .' because the body was empty.', 'webhooks');
                 } else {
                     $this->request($webhook->method, $webhook->url, $headers, $body, $webhook->id);
                 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -21,4 +21,9 @@ class Settings extends Model
      * @var int The time delay in seconds between request attempts.
      */
     public $attemptDelay = 60;
+
+    /**
+     * @var bool Whether if the request body is empty should the request be sent.
+     */
+    public $dontSendEmptyRequestBody = false;
 }


### PR DESCRIPTION
Definitely linked to #6 

When using the payload template using basic twig conditionals is really useful for altering the requestBody. 

This PR allows you to enable a config setting that ignores webhooks (doesn't send them) when the requestBody is empty. I.E. if a conditional wasn't met in the payload template.

This is really useful when not using Zapier based webhooks. 

The config setting defaults to false so existing installations shouldn't be affected. 
