### PR TITLE
Clarify how filters are applied.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Some events can have filters applied to them, which prevent webhooks from being 
 
 <img src="./images/event-filters.png" width="414" height="381" alt="Screenshot of the Event Filters setting">
 
+Ignored filters (`○`) will not have any impact. Positive filters (`✓`) will be required for a webhook to execute, and a negative filter (`×`) will prevent it.
+
 Only element class events and certain `craft\services\Elements` events have any filters out of the box, but modules and plugins can register additional filters using the `craft\webhooks\Plugin::EVENT_REGISTER_FILTER_TYPES` event.
 
 ```php

--- a/src/templates/_manage/edit.html
+++ b/src/templates/_manage/edit.html
@@ -80,9 +80,9 @@
                         <th>{{ filter.displayName }}</th>
                         <td>
                             <div class="btngroup" tabindex="0">
-                                <div class="btn filter-no{% if filter.enabled and not filter.value %} active{% endif %}" data-icon="remove"></div>
-                                <div class="btn filter-ignore{% if not filter.enabled %} active{% endif %}"><div class="status"></div></div>
-                                <div class="btn filter-yes{% if filter.enabled and filter.value %} active{% endif %}" data-icon="checkmark"></div>
+                                <div class="btn filter-no{% if filter.enabled and not filter.value %} active{% endif %}" data-icon="remove" title="{{ 'Prevents webhook execution.'|t('webhooks') }}"></div>
+                                <div class="btn filter-ignore{% if not filter.enabled %} active{% endif %}" title="{{ 'No impact on webhook execution.'|t('webhooks') }}"><div class="status"></div></div>
+                                <div class="btn filter-yes{% if filter.enabled and filter.value %} active{% endif %}" data-icon="checkmark" title="{{ 'Required for webhook execution.'|t('webhooks') }}"></div>
                             </div>
                             <input type="hidden" name="filters[{{ filter.class }}]"{% if filter.enabled %} value="{{ filter.value ? 'yes' : 'no' }}"{% endif %}>
                         </td>
@@ -95,6 +95,7 @@
     {{ forms.field({
         id: 'filters',
         label: 'Event Filters'|t('webhooks'),
+        instructions: 'Checks that can determine whether a webhook should be executed.'|t('webhooks')
     }, filtersInput) }}
 
     {% set urlInput %}


### PR DESCRIPTION
After [troubleshooting with someone in Discord](https://discordapp.com/channels/456442477667418113/544595086743175178/649006988101025793), we both realized we were misunderstanding how webhook filters work.

This PR introduces language to try and clarify how filters are applied: 

1. An explanatory line to the project readme.
2. Instructions for the _Event Filters_ field. 
3. Button tooltips for the individual event filter options.

I don't know any Japanese or I would've added translations.

![screencap](https://user-images.githubusercontent.com/2488775/69678737-0d11bc80-106c-11ea-9c8a-3e50ac150446.gif)
