### PR TITLE
Fix Craft 3.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "rss": "https://github.com/craftcms/webhooks/commits/master.atom"
   },
   "require": {
-    "craftcms/cms": "^3.1.19"
+    "craftcms/cms": "^3.6"
   },
   "autoload": {
     "psr-4": {

--- a/src/templates/_manage/event-autosuggest.html
+++ b/src/templates/_manage/event-autosuggest.html
@@ -3,7 +3,7 @@
 {% block data %}
     {{ parent() }}
     data.senderClassValue = null;
-    data.inputProps.onInputChange = this.myOnInputChange;
+    data.inputAttributes.onInputChange = this.myOnInputChange;
 {% endblock %}
 
 


### PR DESCRIPTION
Craft 3.6 broke compatibility with the Webhooks plugin in this commit https://github.com/craftcms/cms/commit/c6cd93e05f1c1c1bf3667a2cdbad1617ab1daba9
