### PR TITLE
filters: Fix FirstSave and ProvisionalDraft not respecting negation

### DIFF
--- a/src/filters/FirstSaveFilter.php
+++ b/src/filters/FirstSaveFilter.php
@@ -31,6 +31,6 @@ class FirstSaveFilter extends BaseElementFilter
 
     protected static function checkElement(ElementInterface $element, bool $value): bool
     {
-        return $element->firstSave;
+        return $element->firstSave === $value;
     }
 }

--- a/src/filters/ProvisionalDraftFilter.php
+++ b/src/filters/ProvisionalDraftFilter.php
@@ -31,6 +31,6 @@ class ProvisionalDraftFilter extends BaseElementFilter
     protected static function checkElement(ElementInterface $element, bool $value): bool
     {
         $root = ElementHelper::rootElement($element);
-        return $root->isProvisionalDraft;
+        return $root->isProvisionalDraft === $value;
     }
 }


### PR DESCRIPTION
### Description

Fix two filters acting like the "checkbox" (positive) option is selected when the config is "cross" (negative).