### PR TITLE
Fix timezone for request date

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\helpers\ArrayHelper;
 use craft\helpers\ConfigHelper;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\helpers\Queue;
@@ -380,6 +381,7 @@ class Plugin extends \craft\base\Plugin
         if ($data['responseHeaders']) {
             $data['responseHeaders'] = Json::decode($data['responseHeaders']);
         }
+        $data['dateRequested'] = DateTimeHelper::toDateTime($data['dateRequested']);
 
         return $data;
     }

--- a/src/controllers/ActivityController.php
+++ b/src/controllers/ActivityController.php
@@ -5,6 +5,7 @@ namespace craft\webhooks\controllers;
 use Craft;
 use craft\db\Paginator;
 use craft\db\Query;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\web\twig\variables\Paginate;
@@ -43,6 +44,7 @@ class ActivityController extends BaseController
         $requests = $paginator->getPageResults();
         foreach ($requests as &$request) {
             $request['host'] = parse_url($request['url'], PHP_URL_HOST);
+            $request['dateRequested'] = DateTimeHelper::toDateTime($request['dateRequested']);
         }
 
         return $this->renderTemplate('webhooks/_activity/index', [

--- a/src/templates/_activity/details.html
+++ b/src/templates/_activity/details.html
@@ -8,7 +8,7 @@
   {% if request.dateRequested %}
     <div class="data">
       <div class="heading">{{ 'Date'|t('webhooks') }}</div>
-      <div class="value">{{ date(request.dateRequested)|datetime }}</div>
+      <div class="value">{{ request.dateRequested|datetime }}</div>
     </div>
   {% endif %}
   <div class="data">

--- a/src/templates/_activity/index.html
+++ b/src/templates/_activity/index.html
@@ -23,7 +23,7 @@
       <th class="code"><a data-id="{{ request.id }}">{{ request.method|upper }} {{ request.host }}</a></th>
       <td>{{ macros.status(request) }}</td>
       <td>{{ request.attempts }}</td>
-      <td>{{ request.dateRequested ? date(request.dateRequested)|datetime('short') }}</td>
+      <td>{{ request.dateRequested ? request.dateRequested|datetime('short') }}</td>
       <td>{{ macros.responseTime(request) }}</td>
       <td>
         {% if request.webhookId %}


### PR DESCRIPTION
### Description

This fixes the timezone used for the request dates shown in the activity list and detail views. It’s now using the system timezone instead of UTC.

### Related issues

n.a.
