### PR TITLE
Adds migration to increase length of url column

### DIFF
--- a/src/migrations/m240901_112003_url_length.php
+++ b/src/migrations/m240901_112003_url_length.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace craft\webhooks\migrations;
+
+use craft\db\Migration;
+
+/**
+ * m240901_112003_url_length migration.
+ */
+class m240901_112003_url_length extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->alterColumn('{{%webhooks}}', 'url', $this->mediumText()->notNull());
+        $this->alterColumn('{{%webhookrequests}}', 'url', $this->mediumText());
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->alterColumn('{{%webhooks}}', 'url', $this->string()->notNull());
+        $this->alterColumn('{{%webhookrequests}}', 'url', $this->string());
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Description
Im happily using this plugin, but i recently runned into a issue, when i needed to specify webhook url with a quite long 3rd party security token and exceed the limit of `varchar(255)`.
So i created backward compatible migration changing url column data type from `varchar(255)` to `mediumtext`.
